### PR TITLE
[Core] Add Apple Globe key support

### DIFF
--- a/data/constants/keycodes/keycodes_0.0.4_basic.hjson
+++ b/data/constants/keycodes/keycodes_0.0.4_basic.hjson
@@ -1,0 +1,12 @@
+{
+    "keycodes": {
+        "0x00C3": {
+            "group": "media",
+            "key": "KC_GLOBE",
+            "label": "Apple Globe/FN Key",
+            "aliases": [
+                "KC_GLB"
+            ]
+        }
+    }
+}

--- a/quantum/keycodes.h
+++ b/quantum/keycodes.h
@@ -283,6 +283,7 @@ enum qk_keycode_defines {
     KC_ASSISTANT = 0x00C0,
     KC_MISSION_CONTROL = 0x00C1,
     KC_LAUNCHPAD = 0x00C2,
+    KC_GLOBE = 0x00C3,
     KC_MS_UP = 0x00CD,
     KC_MS_DOWN = 0x00CE,
     KC_MS_LEFT = 0x00CF,
@@ -904,6 +905,7 @@ enum qk_keycode_defines {
     KC_ASST    = KC_ASSISTANT,
     KC_MCTL    = KC_MISSION_CONTROL,
     KC_LPAD    = KC_LAUNCHPAD,
+    KC_GLB     = KC_GLOBE,
     KC_MS_U    = KC_MS_UP,
     KC_MS_D    = KC_MS_DOWN,
     KC_MS_L    = KC_MS_LEFT,
@@ -1403,7 +1405,7 @@ enum qk_keycode_defines {
 #define IS_INTERNAL_KEYCODE(code) ((code) >= KC_NO && (code) <= KC_TRANSPARENT)
 #define IS_BASIC_KEYCODE(code) ((code) >= KC_A && (code) <= KC_EXSEL)
 #define IS_SYSTEM_KEYCODE(code) ((code) >= KC_SYSTEM_POWER && (code) <= KC_SYSTEM_WAKE)
-#define IS_CONSUMER_KEYCODE(code) ((code) >= KC_AUDIO_MUTE && (code) <= KC_LAUNCHPAD)
+#define IS_CONSUMER_KEYCODE(code) ((code) >= KC_AUDIO_MUTE && (code) <= KC_GLOBE)
 #define IS_MOUSE_KEYCODE(code) ((code) >= KC_MS_UP && (code) <= KC_MS_ACCEL2)
 #define IS_MODIFIER_KEYCODE(code) ((code) >= KC_LEFT_CTRL && (code) <= KC_RIGHT_GUI)
 #define IS_SWAP_HANDS_KEYCODE(code) ((code) >= QK_SWAP_HANDS_TOGGLE && (code) <= QK_SWAP_HANDS_ONE_SHOT)

--- a/quantum/keymap_common.c
+++ b/quantum/keymap_common.c
@@ -67,7 +67,7 @@ action_t action_for_keycode(uint16_t keycode) {
         case KC_SYSTEM_POWER ... KC_SYSTEM_WAKE:
             action.code = ACTION_USAGE_SYSTEM(KEYCODE2SYSTEM(keycode));
             break;
-        case KC_AUDIO_MUTE ... KC_LAUNCHPAD:
+        case KC_AUDIO_MUTE ... KC_GLOBE:
             action.code = ACTION_USAGE_CONSUMER(KEYCODE2CONSUMER(keycode));
             break;
 #endif

--- a/tests/test_common/keycode_table.cpp
+++ b/tests/test_common/keycode_table.cpp
@@ -225,6 +225,7 @@ std::map<uint16_t, std::string> KEYCODE_ID_TABLE = {
     {KC_ASSISTANT, "KC_ASSISTANT"},
     {KC_MISSION_CONTROL, "KC_MISSION_CONTROL"},
     {KC_LAUNCHPAD, "KC_LAUNCHPAD"},
+    {KC_GLOBE, "KC_GLOBE"},
     {KC_MS_UP, "KC_MS_UP"},
     {KC_MS_DOWN, "KC_MS_DOWN"},
     {KC_MS_LEFT, "KC_MS_LEFT"},

--- a/tmk_core/protocol/report.h
+++ b/tmk_core/protocol/report.h
@@ -104,6 +104,7 @@ enum consumer_usages {
     AC_STOP                = 0x226,
     AC_REFRESH             = 0x227,
     AC_BOOKMARKS           = 0x22A,
+    AC_GLOBE               = 0x29D,
     AC_MISSION_CONTROL     = 0x29F,
     AC_LAUNCHPAD           = 0x2A0
 };
@@ -324,6 +325,8 @@ static inline uint16_t KEYCODE2CONSUMER(uint8_t key) {
             return AC_MISSION_CONTROL;
         case KC_LAUNCHPAD:
             return AC_LAUNCHPAD;
+        case KC_GLOBE:
+            return AC_GLOBE;
         default:
             return 0;
     }


### PR DESCRIPTION
Attempt X at this.  ZMK added it recently, and looking into it, this should be a simple consumer page code (0x29D), and doesn't require any special handling, an Apple supported VID:PID combo, or anything like that.  Just Extrakey enabled, and the appropriate consumer code.  Tested locally.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
